### PR TITLE
Modernize for module support and proper CLI library referencing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-gopocsag
+go-pocsag
 samples
+go.sum

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,30 @@
+module github.com/dhogborg/go-pocsag
+
+go 1.18
+
+replace (
+	github.com/dhogborg/go-pocsag/internal/datatypes => ./internal/datatypes
+	github.com/dhogborg/go-pocsag/internal/pocsag => ./internal/pocsag
+	github.com/dhogborg/go-pocsag/internal/util => ./internal/util
+	github.com/dhogborg/go-pocsag/internal/wav => ./internal/wav
+)
+
+require (
+	github.com/dhogborg/go-pocsag/internal/datatypes v0.0.0-00010101000000-000000000000
+	github.com/dhogborg/go-pocsag/internal/pocsag v0.0.0-00010101000000-000000000000
+	github.com/fatih/color v1.13.0
+	github.com/urfave/cli v1.22.9
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
+)
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/dhogborg/go-pocsag/internal/wav v0.0.0-00010101000000-000000000000 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
+	github.com/kr/text v0.1.0 // indirect
+	github.com/mattn/go-colorable v0.1.9 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+)

--- a/internal/datatypes/go.mod
+++ b/internal/datatypes/go.mod
@@ -1,0 +1,10 @@
+module github.com/dhogborg/go-pocsag/internal/datatypes
+
+go 1.18
+
+require gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
+
+require (
+	github.com/kr/pretty v0.2.1 // indirect
+	github.com/kr/text v0.1.0 // indirect
+)

--- a/internal/pocsag/go.mod
+++ b/internal/pocsag/go.mod
@@ -1,0 +1,9 @@
+module github.com/dhogborg/go-pocsag/internal/pocsag
+
+go 1.18
+
+replace (
+	github.com/dhogborg/go-pocsag/internal/datatypes => ../datatypes
+	github.com/dhogborg/go-pocsag/internal/util => ../util
+	github.com/dhogborg/go-pocsag/internal/wav => ../wav
+)

--- a/internal/wav/go.mod
+++ b/internal/wav/go.mod
@@ -1,0 +1,3 @@
+module github.com/dhogborg/go-pocsag/internal/wav
+
+go 1.18

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/fatih/color"
 
 	"github.com/dhogborg/go-pocsag/internal/datatypes"


### PR DESCRIPTION
Modernize library to make use of go modules and use the new location of the referenced CLI library.